### PR TITLE
Avoid infinite loop in integrate.

### DIFF
--- a/src/density.c
+++ b/src/density.c
@@ -69,7 +69,7 @@ integrate(struct function *F, double a, double b, double step_width)
 {
 	double width = b-a;
 	int N = imax(4, (int) (width / step_width));
-	double step = width / N;
+	double step = fmax(width / N, EPSILON);
 	double x;
 	double result = 0;
 


### PR DESCRIPTION
This patch avoid possible infinite loop in integrate when step is too small.
Related to SO question https://stackoverflow.com/questions/38803871