### PR TITLE
Speed up diffusion parameter handling, fix two vectorisation bugs

### DIFF
--- a/R/diffusion.R
+++ b/R/diffusion.R
@@ -338,7 +338,7 @@ qdiffusion <- function (p, response = "upper",
     if (tmp$objective > max_diff) {
       tmp <- do.call(optimize, args = 
                        c(f = inv_cdf_diffusion, 
-                         interval = list(c(max(interval[1], t0), interval[2])), 
+                         interval = list(c(max(interval[1], t0[op[i]]), interval[2])), 
                          response=response[op[i]], 
                          a=a[op[i]], v=v[op[i]], t0=t0[op[i]], z=z[op[i]], d=d[op[i]], sz=sz[op[i]], 
                          sv=sv[op[i]], st0=st0[op[i]], s=s[op[i]], 
@@ -349,7 +349,7 @@ qdiffusion <- function (p, response = "upper",
     if (tmp$objective > max_diff) {
       tmp <- do.call(optimize, args = 
                        c(f=inv_cdf_diffusion, 
-                         interval = list(c(max(interval[1], t0),max(interval)/2)), 
+                         interval = list(c(max(interval[1], t0[op[i]]),max(interval)/2)), 
                          response=response[op[i]], a=a[op[i]], v=v[op[i]], t0=t0[op[i]], 
                          z=z[op[i]], d=d[op[i]], sz=sz[op[i]], sv=sv[op[i]], 
                          st0=st0[op[i]], s=s[op[i]], precision=precision, 
@@ -360,7 +360,7 @@ qdiffusion <- function (p, response = "upper",
       try({
         uni_tmp <- do.call(uniroot, args = 
                              c(f=inv_cdf_diffusion, 
-                               interval = list(c(max(interval[1], t0), interval[2])), 
+                               interval = list(c(max(interval[1], t0[op[i]]), interval[2])), 
                                response=response[op[i]], 
                                a=a[op[i]], v=v[op[i]], t0=t0[op[i]], z=z[op[i]], d=d[op[i]], 
                                sz=sz[op[i]], sv=sv[op[i]], st0=st0[op[i]], 

--- a/R/diffusion.R
+++ b/R/diffusion.R
@@ -87,8 +87,23 @@
 recalc_t0 <- function (t0, st0) { t0 <- t0 + st0/2 }
 
 
-prepare_diffusion_parameter <- function(response, 
-                                        a, v, t0, z, d, 
+group_parameters <- function(params, nn) {
+  if (nn == 1L || anyNA(params)) {
+    parameter_char <- do.call(paste, c(as.data.frame(params), sep = "\t"))
+    parameter_factor <- factor(parameter_char, levels = unique(parameter_char))
+    return(split(seq_len(nn), f = parameter_factor))
+  }
+  p <- signif(params, 15)
+  o <- do.call(order, as.data.frame(p))
+  ps <- p[o, , drop = FALSE]
+  differs <- rowSums(ps[-1L, , drop = FALSE] != ps[-nn, , drop = FALSE]) > 0
+  idx <- split(o, cumsum(c(TRUE, differs)))
+  idx[order(vapply(idx, min, integer(1)))]
+}
+
+
+prepare_diffusion_parameter <- function(response,
+                                        a, v, t0, z, d,
                                         sz, sv, st0, s, 
                                         nn, 
                                         z_absolute = TRUE, 
@@ -152,9 +167,7 @@ prepare_diffusion_parameter <- function(response,
   
   
   if (!skip_checks) {
-    parameter_char <- apply(params, 1, paste0, collapse = "\t")
-    parameter_factor <- factor(parameter_char, levels = unique(parameter_char))
-    parameter_indices <- split(seq_len(nn), f = parameter_factor)
+    parameter_indices <- group_parameters(params, nn)
   } else {
     if (all(numeric_bounds == 2L) | all(numeric_bounds == 1L)) {
       parameter_indices <- list(
@@ -437,10 +450,8 @@ rdiffusion <- function (n,
     randBounds <- vector("numeric",length=n)
     
     #uniques <- unique(params)
-    parameter_char <- apply(params, 1, paste0, collapse = "\t")
-    parameter_factor <- factor(parameter_char, levels = unique(parameter_char))
-    parameter_indices <- split(seq_len(n), f = parameter_factor)
-    
+    parameter_indices <- group_parameters(params, n)
+
     for (i in seq_len(length(parameter_indices))) {
       ok_rows <- parameter_indices[[i]]
       

--- a/R/diffusion.R
+++ b/R/diffusion.R
@@ -250,19 +250,21 @@ pdiffusion <- function (rt, response = "upper",
   if (use_precise) {
     for (i in seq_len(length(pars$parameter_indices))) {
       ok_rows <- pars$parameter_indices[[i]]
-      pvalues[ok_rows] <- p_precise_fastdm (rt[ok_rows], 
-                                        pars$params[ok_rows[1],1:8], 
-                                        precision, 
-                                        pars$params[ok_rows[1],9], 
+      ok_rows <- ok_rows[order(rt[ok_rows])]
+      pvalues[ok_rows] <- p_precise_fastdm (rt[ok_rows],
+                                        pars$params[ok_rows[1],1:8],
+                                        precision,
+                                        pars$params[ok_rows[1],9],
                                         stop_on_error)
     }
   } else {
     for (i in seq_len(length(pars$parameter_indices))) {
       ok_rows <- pars$parameter_indices[[i]]
-      pvalues[ok_rows] <- p_fastdm (rt[ok_rows], 
-                                pars$params[ok_rows[1],1:8], 
-                                precision, 
-                                pars$params[ok_rows[1],9], 
+      ok_rows <- ok_rows[order(rt[ok_rows])]
+      pvalues[ok_rows] <- p_fastdm (rt[ok_rows],
+                                pars$params[ok_rows[1],1:8],
+                                precision,
+                                pars$params[ok_rows[1],9],
                                 stop_on_error)
     }
   }


### PR DESCRIPTION
@singmann Three changes to `R/diffusion.R`. The first is a speedup and leaves output unchanged.

## Faster detection of unique parameter sets

The diffusion functions call the C code once per distinct parameter set. They found those sets by pasting every row of the parameter matrix into a string. Turning doubles into text is slow, and it happens on every call, so it ended up dominating model fitting. In profiling fit it was 95% of the runtime, against 3% in `d_fastdm`.

`group_parameters()` replaces that. It sorts the numeric matrix and marks runs of equal neighbouring rows. The grouping itself is the same as before. `signif(, 15)` matches the 15 significant digits `as.character()` used, so rows that used to be merged still are. Anything with `NA` or `NaN` in it falls back to the old string method, because `order()` cannot tell those two apart. Groups still come back in first-appearance order, which matters since `rdiffusion` draws random numbers per group and a different order would change the stream for a given seed.

The grouping step on its own goes from 4.22 ms to 0.24 ms at 1,000 trials, and from 87.2 ms to 4.2 ms at 20,000 (median of 15 runs).

A Nelder-Mead fit with trial-wise `a` and `v`:

| trials | before | after | |
|---|---|---|---|
| 100 | 0.257 s | 0.056 s | 4.6x |
| 200 | 0.488 s | 0.082 s | 6.0x |
| 500 | 1.216 s | 0.170 s | 7.2x |
| 1,000 | 2.384 s | 0.286 s | 8.3x |
| 2,000 | 4.743 s | 0.537 s | 8.8x |

All of them land on the same optimum.

<img width="1750" height="780" alt="rtdists-parameter-grouping-benchmark" src="https://github.com/user-attachments/assets/ce27730f-4115-4d2c-bf7e-87a4c43d77df" />


Now here are two other things I noted along the way. These two fix bugs changing what the package returns.

## pdiffusion gave wrong values when rt was not sorted

If `rt` was not increasing within a parameter set, `pdiffusion` quietly returned wrong probabilities(?). The error got as large as 0.79 on a quantity bounded by 0 and 1, and the CDF it returned was not monotone. The same input segfaulted when `sz`, `sv` and `st0` were all non-zero. Response time data is not sorted, so this is the normal way the function gets called.

The cause is in the C code. It advances a PDE forward in time and will not step backwards, because of the `if (t > data->t)` guard in `CDF_no_variability.h`. Out of order input therefore reuses stale state. With `st0` the same input pushes a ring buffer index negative in `F_st0_get_row`, which is the crash. There used to be a guard against unsorted input, but it was commented out rather than fixed.

The fix sorts each parameter group by `rt` before passing it to C, then puts each value back where it came from, so the result still lines up with the `rt` the caller gave. Against a per-element reference at n = 400 with unsorted input, the largest error drops from 0.794 to 0.00083, which is what `precision = 3` allows. `ddiffusion` never had this problem and is untouched.

## qdiffusion ignored trial-wise t0

Three `optimize()` calls built their search interval from the whole `t0` vector instead of the value for the trial being solved. Every other argument in the same calls used `t0[op[i]]`. With a vectorised `t0` the lower bound became the largest `t0` across all trials, so any trial with a smaller `t0` had its quantile fall outside the interval and came back as `NA`, with a warning about not being able to obtain the RT.

With `p = c(.2, .5, .8)` and `t0 = c(0.2, 0.9, 0.2)`, `qdiffusion` returned `NA, 1.06917, NA`. The right answers are `0.28307, 1.06917, 0.59183`. It now matches element-wise calls. A scalar `t0` behaves exactly as before, which is why the current tests do not catch this.

## Testing

`R CMD check --as-cran` passes: 2872 tests, no errors or warnings. The suite also passes with `NOT_CRAN=true`, which runs the 15 tests skipped on CRAN, including the `pdiffusion` ones.

I checked the new grouping against the old one on 23 edge cases (`NA`, `NaN`, `Inf` and `-Inf`, signed zero, values differing below 15 significant digits, all-unique parameters, n = 1) plus 6000 random cases. It agreed every time. I also installed the parent commit into a separate library and compared output across 25 scenarios. `ddiffusion` and `rdiffusion` gave the same numbers to the last digit, including every path that uses random numbers.

Both bugs only show up with vectorised parameters, and the suite passes without either fix, which is how they went unnoticed. Maybe we can also think about adding tests that separately.